### PR TITLE
feat: Add wrangler.toml to configure static site deployment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "ux-india-2025"
+compatibility_date = "2025-09-10"
+
+[pages_build_output]
+dir = "."


### PR DESCRIPTION
The deployment was failing with an error indicating that the entry point for the worker or assets directory was missing. This was because the `wrangler` CLI tool did not have a configuration file to specify what to deploy.

This change adds a `wrangler.toml` file to the root of the project. This file configures the project for deployment to Cloudflare Pages, specifying the current directory as the location of the static assets. This will resolve the deployment error.